### PR TITLE
major edits to the about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,15 +3,45 @@ layout: about
 title: About
 ---
 
-<h2>About</h2>
+<h1>
+    About
+</h1>
+
+<!--PURPOSE-->
+<h2>
+    Our Purpose
+</h2>
 
 <p>
-:art:&nbsp;Yet another theme for elegant writers with modern flat style
-and beautiful night mode.
+    This collection articles and other media reflects work produced by a collection of data professionals who have decided to feature their learnings, musings, and other forms of reflection on aspects of the wide world of data science here on this blog.
+</p>
+
+<!--The PEOPLE-->
+<h2>
+    Who we Are
+</h2>
+
+<p>
+    The authors of this blog are data professionals with varied backgrounds. What binds them together is a passion for learning, a desire to add quantitative relationships to observations, and a dedication toward integrating measurement with computational methods and devices.
+</p>
+
+<P>
+    The reader is encouraged to reach out to the authors of each article to engage in follow up conversation.
+</P>
+
+<!--EXPECTATIONS-->
+<h2>
+    What the Reader can Expect from Us
+</h2>
+
+<p>
+    We hope the readers of this blog will find the content created on this blog technically relevant, thought provoking, engaging, and, at times, entertaining to read.
 </p>
 
 <p>
-Hey, nice to meet you, you found this Jekyll theme. Here the yet another
-theme is a modern theme, and it's quite clear, clean and neat for writers
-and posts.
+    Furthermore, the reader can expect that the examples shared are (1) open-source and can be executed locally in the vast majority of cases, (2) work drawn from other sources is well-cited to allow for connections to source material, (3) AI-generated work will be labelled, and (4) the authors will do their best to keep up with good-faith questions from readers.
+</p>
+
+<p>
+    Finally, it is the sincere hope that the reader of this content will enjoy it; after all, data science can be a ton of fun!
 </p>

--- a/about.html
+++ b/about.html
@@ -9,7 +9,7 @@ title: About
 </h2>
 
 <p>
-    This collection articles and other media reflects work produced by a collection of data professionals who have
+    This collection of articles and other media reflects work produced by data professionals who have
     decided to feature their learnings, musings, and other forms of reflection on aspects of the wide world of data
     science here on this blog.
 </p>
@@ -35,7 +35,7 @@ title: About
 </h2>
 
 <p>
-    We hope the readers of this blog will find the content created on this blog technically relevant, thought provoking,
+    We hope the readers of this blog will find the content technically relevant, thought provoking,
     engaging, and, at times, entertaining to read.
 </p>
 

--- a/about.html
+++ b/about.html
@@ -3,17 +3,15 @@ layout: about
 title: About
 ---
 
-<h1>
-    About
-</h1>
-
 <!--PURPOSE-->
 <h2>
     Our Purpose
 </h2>
 
 <p>
-    This collection articles and other media reflects work produced by a collection of data professionals who have decided to feature their learnings, musings, and other forms of reflection on aspects of the wide world of data science here on this blog.
+    This collection articles and other media reflects work produced by a collection of data professionals who have
+    decided to feature their learnings, musings, and other forms of reflection on aspects of the wide world of data
+    science here on this blog.
 </p>
 
 <!--The PEOPLE-->
@@ -22,7 +20,9 @@ title: About
 </h2>
 
 <p>
-    The authors of this blog are data professionals with varied backgrounds. What binds them together is a passion for learning, a desire to add quantitative relationships to observations, and a dedication toward integrating measurement with computational methods and devices.
+    The authors of this blog are data professionals with varied backgrounds. What binds them together is a passion for
+    learning, a desire to add quantitative relationships to observations, and a dedication toward integrating
+    measurement with computational methods and devices.
 </p>
 
 <P>
@@ -35,13 +35,18 @@ title: About
 </h2>
 
 <p>
-    We hope the readers of this blog will find the content created on this blog technically relevant, thought provoking, engaging, and, at times, entertaining to read.
+    We hope the readers of this blog will find the content created on this blog technically relevant, thought provoking,
+    engaging, and, at times, entertaining to read.
 </p>
 
 <p>
-    Furthermore, the reader can expect that the examples shared are (1) open-source and can be executed locally in the vast majority of cases, (2) work drawn from other sources is well-cited to allow for connections to source material, (3) AI-generated work will be labelled, and (4) the authors will do their best to keep up with good-faith questions from readers.
+    Furthermore, the reader can expect that the examples shared are (1) open-source and can be executed locally in the
+    vast majority of cases, (2) work drawn from other sources is well-cited to allow for connections to source material,
+    (3) AI-generated work will be labelled, and (4) the authors will do their best to keep up with good-faith questions
+    from readers.
 </p>
 
 <p>
-    Finally, it is the sincere hope that the reader of this content will enjoy it; after all, data science can be a ton of fun!
+    Finally, it is the sincere hope that the reader of this content will enjoy it; after all, data science can be a ton
+    of fun!
 </p>


### PR DESCRIPTION
- to address issue #2, I have edited the about page in  format so that it reflects the three goals: a) purpose, b) people, and c) expectations

- it is my belief that this meets the minimum threshold to close #2.

- ~one small thing: I do not full understand the 'layout:' and 'title' things at the top. I will need to build the site locally to find out if they are showing up on the page.~

- I was able to serve the site locally after installing three or four more gems (e.g., `jekyll-paginate`, `jekyll-spaceship`) and I could see my changes to the "About" page. The title of the page appears to be very small. So I am open to reopening up this issue down the road if we want to fix that. For now, the goals have been accomplished as stated in the first bullet point